### PR TITLE
use new syntax for typedefs (error 196)

### DIFF
--- a/socket.inc
+++ b/socket.inc
@@ -200,9 +200,14 @@ enum SocketOption {
  * @param arg		The argument set by SocketSetArg()
  * @noreturn
  */
-funcenum SocketConnectCB
+//funcenum SocketConnectCB
+//{
+//    public(Handle:socket, any:arg)
+//};
+
+typeset SocketConnectCB
 {
-    public(Handle:socket, any:arg)
+    function void (Handle socket, any arg);
 };
 
 /**
@@ -216,9 +221,9 @@ funcenum SocketConnectCB
  * @param any		arg			The argument set by SocketSetArg() for the listen-socket
  * @noreturn
  */
-funcenum SocketIncomingCB
+typeset SocketIncomingCB
 {
-    public(Handle:socket, Handle:newSocket, const String:remoteIP[], remotePort, any:arg)
+    function void (Handle socket, Handle newSocket, const char remoteIP[], int remotePort, any arg)
 };
 
 /**
@@ -235,9 +240,9 @@ funcenum SocketIncomingCB
  * @param any		arg			The argument set by SocketSetArg() for the socket
  * @noreturn
  */
-funcenum SocketReceiveCB
+typeset SocketReceiveCB
 {
-    public(Handle:socket, const String:receiveData[], const dataSize, any:arg)
+    function void (Handle socket, const char receiveData[], const int dataSize, any arg)
 };
 
 /**
@@ -247,9 +252,9 @@ funcenum SocketReceiveCB
  * @param any		arg			The argument set by SocketSetArg() for the socket
  * @noreturn
  */
-funcenum SocketSendqueueEmptyCB
+typeset SocketSendqueueEmptyCB
 {
-    public(Handle:socket, any:arg)
+    function void (Handle socket, any arg)
 };
 
 /**
@@ -261,9 +266,9 @@ funcenum SocketSendqueueEmptyCB
  * @param any		arg			The argument set by SocketSetArg() for the socket
  * @noreturn
  */
-funcenum SocketDisconnectCB
+typeset SocketDisconnectCB
 {
-    public(Handle:socket, any:arg)
+    function void (Handle socket, any arg)
 };
 
 /**
@@ -277,9 +282,9 @@ funcenum SocketDisconnectCB
  * @param any		arg			The argument set by SocketSetArg() for the socket
  * @noreturn
  */
-funcenum SocketErrorCB
+typeset SocketErrorCB
 {
-    public(Handle:socket, const errorType, const errorNum, any:arg)
+    function void (Handle socket, const int errorType, const int errorNum, any arg)
 };
 
 


### PR DESCRIPTION
The old syntax was deprecated a while ago and wont working with newer versions of sourcemod.